### PR TITLE
Remove the uncessary logging package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,6 @@ idna==3.6
 injector==0.21.0
 itsdangerous==2.1.2
 Jinja2==3.1.2
-logging==0.4.9.6
 Mako==1.3.0
 MarkupSafe==2.1.3
 openai==1.12.0


### PR DESCRIPTION
To resolve issue
**Collecting logging==0.4.9.6 (from -r requirements.txt (line 27))
  Downloading logging-0.4.9.6.tar.gz (96 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 96.0/96.0 kB 6.5 MB/s eta 0:00:00
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [19 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 14, in <module>
        File "/usr/local/lib/python3.11/site-packages/setuptools/__init__.py", line 16, in <module>
          import setuptools.version
        File "/usr/local/lib/python3.11/site-packages/setuptools/version.py", line 1, in <module>
          import pkg_resources
        File "/usr/local/lib/python3.11/site-packages/pkg_resources/__init__.py", line 83, in <module>
          __import__('pkg_resources.extern.packaging.specifiers')
        File "/usr/local/lib/python3.11/site-packages/pkg_resources/_vendor/packaging/specifiers.py", line 24, in <module>
          from .utils import canonicalize_version
        File "/usr/local/lib/python3.11/site-packages/pkg_resources/_vendor/packaging/utils.py", line 8, in <module>
          from .tags import Tag, parse_tag
        File "/usr/local/lib/python3.11/site-packages/pkg_resources/_vendor/packaging/tags.py", line 5, in <module>
          import logging
        File "/tmp/pip-install-y1ugmyv7/logging_5dead42fe18d4875a819e02fc3ca1656/logging/__init__.py", line 618
          raise NotImplementedError, 'emit must be implemented '\
                                   ^
      SyntaxError: invalid syntax
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata**